### PR TITLE
bugfix collection push

### DIFF
--- a/src/Collections/AbstractTypedCollection.php
+++ b/src/Collections/AbstractTypedCollection.php
@@ -18,7 +18,7 @@ abstract class AbstractTypedCollection extends Collection
         parent::__construct($items);
     }
 
-    public function push($value)
+    public function push(...$value)
     {
         $this->validateType($value);
 

--- a/src/Collections/AbstractTypedCollection.php
+++ b/src/Collections/AbstractTypedCollection.php
@@ -20,9 +20,12 @@ abstract class AbstractTypedCollection extends Collection
 
     public function push(...$value)
     {
-        $this->validateType($value);
+        foreach ($value as $item) {
+            $this->validateType($item);
+            parent::push($item);
+        }
 
-        return parent::push($value);
+        return $this;
     }
 
     public function put($key, $value)


### PR DESCRIPTION
Declaration of Nxu\TypedCollection\Collections\AbstractTypedCollection::push($value) should be compatible with Illuminate\Support\Collection::push(...$values)